### PR TITLE
feat: Support CFS as corefile storage backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,61 @@ spec:
 
 ## 配置说明
 
+### 存储方案选择
+
+CoreDog 支持三种存储后端：
+
+| 方案 | Protocol | 优点 | 适用场景 |
+|-----|----------|------|--------|
+| **S3** | `s3` | 标准 S3 API，兼容性强 | AWS 用户，通用场景 |
+| **COS** | `cos` | 腾讯云原生，性能优化 | 腾讯云环境 |
+| **CFS** | `cfs` | 文件存储，支持 POSIX 接口 | 需要文件系统语义，本地/专线上传 |
+
+#### S3 配置示例
+
+```yaml
+StorageConfig:
+  protocol: s3
+  s3AccesskeyID: "your_ak"
+  s3SecretAccessKey: "your_sk"
+  s3Region: "us-east-1"
+  S3Bucket: "my-bucket"
+  S3Endpoint: "s3.amazonaws.com"
+```
+
+#### COS 配置示例
+
+```yaml
+StorageConfig:
+  protocol: cos
+  s3AccesskeyID: "your_ak"
+  s3SecretAccessKey: "your_sk"
+  s3Region: "ap-nanjing"
+  S3Bucket: "my-bucket-1234567890"
+  S3Endpoint: "cos.ap-nanjing.myqcloud.com"
+```
+
+#### CFS 配置示例
+
+**前置条件**：CFS 已挂载到集群节点
+
+```yaml
+StorageConfig:
+  protocol: cfs
+  CFSMountPath: "/mnt/cfs"      # CFS 挂载路径
+  StoreDir: "corefiles"          # CFS 内的存储目录
+  DeleteLocalCorefile: true
+```
+
+**配置 Watcher Pod 的 volume 挂载**（在 Helm values 中）：
+
+```yaml
+corefileVolume:
+  type: hostPath
+  hostPath:
+    path: /mnt/cfs                # 与 CFSMountPath 一致
+```
+
 ### values.yaml 必填配置
 
 编辑 `charts/values.yaml`：
@@ -94,10 +149,23 @@ spec:
 config:
   coredog: |-
     StorageConfig:
-      # ⚠️ S3 配置（必填）
+      # 存储协议选择
+      protocol: s3                           # s3: S3/COS, cfs: CFS（默认 s3）
+      
+      # === 若使用 S3 或 COS 存储 ===
       s3AccesskeyID: "YOUR_ACCESS_KEY"
       s3SecretAccessKey: "YOUR_SECRET_KEY"
       s3Region: "ap-nanjing"
+      S3Bucket: "your-bucket"
+      S3Endpoint: "cos.ap-nanjing.myqcloud.com"  # COS 填这个，S3 填 S3 endpoint
+      
+      # === 若使用 CFS 存储 ===
+      CFSMountPath: "/mnt/cfs"               # CFS 挂载路径
+      
+      # 通用配置
+      StoreDir: corefiles                    # 存储目录
+      DeleteLocalCorefile: true              # 上传后删除本地文件
+```
       S3Bucket: "your-bucket"
       S3Endpoint: "cos.ap-nanjing.myqcloud.com"
       

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -15,21 +15,28 @@ image:
 # ----------------------------------------------------------------------------
 config:
   coredog: |-
-    # S3 存储配置 - 用于上传 core dump 文件
+    # 存储配置 - 用于上传 core dump 文件
     StorageConfig:
       enabled: true                          # 是否启用云存储上传
-      protocol: s3                           # 存储协议，目前仅支持 s3
+      protocol: s3                           # 存储协议: s3, cos, cfs
+                                             #   - s3: Amazon S3 对象存储
+                                             #   - cos: 腾讯云 COS 对象存储（兼容 S3 API）
+                                             #   - cfs: 腾讯云 CFS 文件存储
       
+      # ===== S3/COS 配置（当 protocol=s3 或 protocol=cos 时使用）=====
       # ⚠️ 必填项：S3 访问凭证
-      s3AccesskeyID: ""                      # 填写您的 S3 Access Key ID
-      s3SecretAccessKey: ""                  # 填写您的 S3 Secret Access Key
-      s3Region: ""                           # 填写 S3 区域，如: us-east-1, ap-nanjing
-      S3Bucket: ""                           # 填写 S3 bucket 名称
-      S3Endpoint: ""                         # 填写 S3 endpoint，如: s3.amazonaws.com, cos.ap-nanjing.myqcloud.com
+      s3AccesskeyID: ""                      # 填写您的 S3/COS Access Key ID
+      s3SecretAccessKey: ""                  # 填写您的 S3/COS Secret Access Key
+      s3Region: ""                           # 填写 S3/COS 区域，如: us-east-1, ap-nanjing
+      S3Bucket: ""                           # 填写 S3/COS bucket 名称
+      S3Endpoint: ""                         # 填写 S3/COS endpoint，如: s3.amazonaws.com, cos.ap-nanjing.myqcloud.com
       
-      # 可选配置
-      StoreDir: corefiles                    # S3 中的存储目录前缀
-      PresignedURLExpireSeconds: 3600        # 预签名 URL 有效期（秒）
+      # ===== CFS 配置（当 protocol=cfs 时使用）=====
+      CFSMountPath: ""                       # CFS 挂载路径，如: /mnt/cfs
+      
+      # 通用配置
+      StoreDir: corefiles                    # 存储目录前缀
+      PresignedURLExpireSeconds: 3600        # 预签名 URL 有效期（秒，仅 S3/COS 使用）
       
       # ⚠️ 重要：本地文件清理配置
       DeleteLocalCorefile: true              # 上传成功后是否删除本地文件（强烈推荐设为 true，避免磁盘被占满）

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -69,12 +69,14 @@ func Run() {
 	if err := w.Watch(wcfg.CorefileDir); err != nil {
 		logrus.Fatal(err)
 	}
-	storeClient, err := store.NewS3Store(
+	storeClient, err := store.NewStore(
+		wcfg.StorageConfig.Protocol,
 		wcfg.StorageConfig.S3Region,
 		wcfg.StorageConfig.S3AccessKeyID,
 		wcfg.StorageConfig.S3SecretAccessKey,
 		wcfg.StorageConfig.S3Bucket,
 		wcfg.StorageConfig.S3Endpoint,
+		wcfg.StorageConfig.CFSMountPath,
 		wcfg.StorageConfig.StoreDir,
 		wcfg.StorageConfig.PresignedURLExpireSeconds,
 	)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 		S3Region                  string `yaml:"s3Region"`
 		S3Bucket                  string `yaml:"S3Bucket"`
 		S3Endpoint                string `yaml:"S3Endpoint"`
+		CFSMountPath              string `yaml:"CFSMountPath"`
 		StoreDir                  string `yaml:"StoreDir"`
 		PresignedURLExpireSeconds int    `yaml:"PresignedURLExpireSeconds"`
 		DeleteLocalCorefile       bool   `yaml:"deleteLocalCorefile"`

--- a/internal/store/cfs.go
+++ b/internal/store/cfs.go
@@ -1,0 +1,86 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// CFSStore implements the Store interface for CFS (Cloud File System)
+type CFSStore struct {
+	MountPath string
+	StoreDir  string
+}
+
+// Upload uploads the corefile to the CFS mount point
+// Returns the local file path (since CFS is a mounted filesystem)
+func (cs *CFSStore) Upload(ctx context.Context, path string) (downloadurl string, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to open corefile")
+	}
+	defer f.Close()
+
+	// Create the destination path
+	_, filename := filepath.Split(path)
+	destDir := filepath.Join(cs.MountPath, cs.StoreDir)
+
+	// Ensure destination directory exists
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return "", errors.Wrap(err, "failed to create destination directory")
+	}
+
+	destPath := filepath.Join(destDir, filename)
+
+	// Create the destination file
+	destFile, err := os.Create(destPath)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create destination file")
+	}
+	defer destFile.Close()
+
+	// Copy the file content
+	if _, err := io.Copy(destFile, f); err != nil {
+		return "", errors.Wrap(err, "failed to copy file to CFS")
+	}
+
+	// Ensure file is synced to disk
+	if err := destFile.Sync(); err != nil {
+		return "", errors.Wrap(err, "failed to sync file to CFS")
+	}
+
+	// Return the CFS path as download URL
+	// Typically: cfs://mount-id/storeDir/filename or file path
+	downloadurl = fmt.Sprintf("cfs://%s/%s", destDir, filename)
+
+	return downloadurl, nil
+}
+
+// NewCFSStore creates a new CFS store instance
+func NewCFSStore(mountPath, storedir string) (Store, error) {
+	// Validate mount path exists and is accessible
+	info, err := os.Stat(mountPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "CFS mount path %s is not accessible", mountPath)
+	}
+	if !info.IsDir() {
+		return nil, errors.Errorf("CFS mount path %s is not a directory", mountPath)
+	}
+
+	// Test write permission
+	testFile := filepath.Join(mountPath, ".coredog_write_test_"+fmt.Sprintf("%d", time.Now().Unix()))
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		return nil, errors.Wrapf(err, "CFS mount path %s is not writable", mountPath)
+	}
+	os.Remove(testFile)
+
+	return &CFSStore{
+		MountPath: mountPath,
+		StoreDir:  storedir,
+	}, nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -85,4 +86,22 @@ func NewS3Store(region, akid, aksecret, bucket, endpoint, storedir string, presi
 	}
 	store.uploader = uploader
 	return store, nil
+}
+
+// NewStore creates a Store instance based on the protocol
+// protocol: "s3" for S3/COS, "cfs" for CFS
+func NewStore(protocol, region, akid, aksecret, bucket, endpoint, cfsMountPath, storedir string, presignExpire int) (Store, error) {
+	protocol = strings.ToLower(strings.TrimSpace(protocol))
+	if protocol == "" {
+		protocol = "s3"
+	}
+
+	switch protocol {
+	case "s3", "cos":
+		return NewS3Store(region, akid, aksecret, bucket, endpoint, storedir, presignExpire)
+	case "cfs":
+		return NewCFSStore(cfsMountPath, storedir)
+	default:
+		return nil, errors.Errorf("unsupported storage protocol: %s", protocol)
+	}
 }


### PR DESCRIPTION
- Add CFSStore implementation for direct filesystem storage
- Add protocol field to support s3, cos, cfs storage backends
- Add CFSMountPath configuration option
- Implement factory function NewStore() to select backend by protocol
- Update values.yaml with CFS configuration examples
- Update README with storage options comparison and CFS usage guide
- Maintain backward compatibility with existing S3/COS configurations